### PR TITLE
fix: add mobile responsiveness for google form

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,10 +28,6 @@ const ColSubheader = styled.h3`
   font-size: 1.4rem;
   font-weight: 600;
 `;
-const SignFormContainer = styled.div`
-  position: relative;
-  width: 100%;
-`;
 const SignForm = styled.iframe`
   height: 912px;
   @media (max-width: 700px) {
@@ -65,18 +61,15 @@ const IndexPage = () => (
           }
         </P>
       </Col>
-      <SignFormContainer>
-        <SignForm
-          src="https://docs.google.com/forms/d/e/1FAIpQLSfne-M3nsCh0aNiYx_C5AOEXPlzD-64eK_pv7GZoZolFzRqqQ/viewform?embedded=true"
-          frameBorder="0"
-          marginHeight="0"
-          marginWidth="0"
+      <SignForm
+        src="https://docs.google.com/forms/d/e/1FAIpQLSfne-M3nsCh0aNiYx_C5AOEXPlzD-64eK_pv7GZoZolFzRqqQ/viewform?embedded=true"
+        frameBorder="0"
+        marginHeight="0"
+        marginWidth="0"
 
-        >
-          Loading...
-        </SignForm>
-      </SignFormContainer>
-
+      >
+        Loading...
+      </SignForm>
       <Col>
         <ColHeader>FAQs</ColHeader>
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -28,6 +28,21 @@ const ColSubheader = styled.h3`
   font-size: 1.4rem;
   font-weight: 600;
 `;
+const SignFormContainer = styled.div`
+  position: relative;
+  width: 100%;
+`;
+const SignForm = styled.iframe`
+  height: 912px;
+  @media (max-width: 700px) {
+    height: 970px
+  }
+  @media (max-width: 375px) {
+    height: 1045px
+  }
+  margin-bottom: 0;
+  width: 100%;
+`;
 
 const P = styled.p`
   margin-bottom: 2rem;
@@ -50,20 +65,17 @@ const IndexPage = () => (
           }
         </P>
       </Col>
+      <SignFormContainer>
+        <SignForm
+          src="https://docs.google.com/forms/d/e/1FAIpQLSfne-M3nsCh0aNiYx_C5AOEXPlzD-64eK_pv7GZoZolFzRqqQ/viewform?embedded=true"
+          frameBorder="0"
+          marginHeight="0"
+          marginWidth="0"
 
-      <iframe
-        src="https://docs.google.com/forms/d/e/1FAIpQLSfne-M3nsCh0aNiYx_C5AOEXPlzD-64eK_pv7GZoZolFzRqqQ/viewform?embedded=true"
-        width="640"
-        height="915"
-        frameBorder="0"
-        marginHeight="0"
-        marginWidth="0"
-        style={{
-          marginBottom: 0
-        }}
-      >
-        Loading...
-      </iframe>
+        >
+          Loading...
+        </SignForm>
+      </SignFormContainer>
 
       <Col>
         <ColHeader>FAQs</ColHeader>


### PR DESCRIPTION
What this diff does:
- Adds width: 100% to embed form
- Conditionally adjusts height by media breakpoint

<img width="323" alt="Screen Shot 2019-04-14 at 7 45 55 PM" src="https://user-images.githubusercontent.com/12662241/56105077-6f5be980-5eef-11e9-9756-a948869c2e04.png">
<img width="404" alt="Screen Shot 2019-04-14 at 7 45 40 PM" src="https://user-images.githubusercontent.com/12662241/56105083-72ef7080-5eef-11e9-9851-aa72087aa3d5.png">
