### PR TITLE
Fix spreadsheet column headers in script

### DIFF
--- a/scripts/update-signers.js
+++ b/scripts/update-signers.js
@@ -1,6 +1,12 @@
 /* eslint-disable no-process-env, no-console */
 const GoogleSpreadsheet = require('google-spreadsheet');
 
+const SPREADSHEET_ID = '14dL-8nYBdlS0Ip055-HgPj81IvVLEGvzNZQwPpMZXVU';
+// We appear to be stuck with these column headers - they're set by the form.
+const NAME_COL =
+  'itheundersignedcurrentorformeruberemployeepledgetodonateatleast2ofthevalueofmyuberequitytocharity.';
+const JOB_COL = 'jobtitleoptional';
+
 const spreadsheetCredentialsPath = process.env.CREDENTIALS;
 if (!spreadsheetCredentialsPath) {
   throw new Error(
@@ -11,9 +17,7 @@ if (!spreadsheetCredentialsPath) {
 const creds = require(spreadsheetCredentialsPath);
 
 // Create a document object using the ID of the spreadsheet
-const doc = new GoogleSpreadsheet(
-  '14dL-8nYBdlS0Ip055-HgPj81IvVLEGvzNZQwPpMZXVU'
-);
+const doc = new GoogleSpreadsheet(SPREADSHEET_ID);
 
 // Authenticate with the Google Spreadsheets API.
 doc.useServiceAccountAuth(creds, authErr => {
@@ -27,7 +31,7 @@ doc.useServiceAccountAuth(creds, authErr => {
     }
     const cleanRows = rows
       .filter(row => Boolean(row.ok))
-      .map(({name, jobtitle}) => ({name, jobtitle}));
+      .map(row => ({name: row[NAME_COL], jobtitle: row[JOB_COL]}));
     console.log(JSON.stringify(cleanRows, null, '  '));
   });
 });


### PR DESCRIPTION
I thought I could edit the headers in the spreadsheet, but apparently when someone submits the form they get reset. So we're stuck with the header `itheundersignedcurrentorformeruberemployeepledgetodonateatleast2ofthevalueofmyuberequitytocharity.`

This underscores that we probably can't edit the form questions now without potentially messing up the spreadsheet, so we need to be pretty careful.