### PR TITLE
Fix deployment script to include the CNAME record

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,10 @@
     "prettier": "^1.16.4"
   },
   "scripts": {
-    "build": "gatsby build",
-    "deploy": "yarn build && gh-pages -d public",
+    "build": "yarn clean && gatsby build",
+    "clean": "rm -rf public",
+    "copy-cname": "cp src/data/CNAME public",
+    "deploy": "yarn build && yarn copy-cname && gh-pages -d public",
     "develop": "gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",
     "start": "yarn develop",

--- a/src/data/CNAME
+++ b/src/data/CNAME
@@ -1,0 +1,1 @@
+www.twopercentpledge.org


### PR DESCRIPTION
I didn't realize that GitHub tracks the custom domain by putting a `CNAME` record file into `gh-pages`. The previous `deploy` script was force-pushing over this. This diff checks the `CNAME` record into the repo and copies it to the built files. It also cleans the `public` directory between builds - we were previously keeping and pushing old versions as well as new to the branch.

Gatsby still sticks a lot of cruft in here, and we might want to see if we can remove it - there's 54Kb of application JS that shouldn't be necessary at all. But doesn't seem harmful at present.