### PR TITLE
fix: add key to mapped items

### DIFF
--- a/src/components/signatories.js
+++ b/src/components/signatories.js
@@ -11,8 +11,8 @@ const LI = styled.li`
 export default function Signatories() {
   return (
     <UL>
-      {signers.map(({name, jobtitle}) => (
-        <LI>{`${name}, ${jobtitle}`}</LI>
+      {signers.map(({name, jobtitle}, index) => (
+        <LI key={`${name}_${index}`}>{`${name}, ${jobtitle}`}</LI>
       ))}
     </UL>
   );


### PR DESCRIPTION
Need a unique key to prevent react console errors.  Suffixed it with index to prevent react flattening 'Anonymous' as duplicates