### PR TITLE
Fix formatting when job title is not provided

### DIFF
--- a/src/components/signatories.js
+++ b/src/components/signatories.js
@@ -12,7 +12,9 @@ export default function Signatories() {
   return (
     <UL>
       {signers.map(({name, jobtitle}, index) => (
-        <LI key={`${name}_${index}`}>{`${name}, ${jobtitle}`}</LI>
+        <LI key={`${name}_${index}`}>
+          {[name, jobtitle].filter(Boolean).join(', ')}
+        </LI>
       ))}
     </UL>
   );


### PR DESCRIPTION
Drops the comma when there's no job title.