### PR TITLE
Add disclaimer about manual review and updates

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -43,6 +43,11 @@ const SignForm = styled.iframe`
 const P = styled.p`
   margin-bottom: 2rem;
 `;
+const HelpText = styled.p`
+  font-size: 1rem;
+  font-style: italic;
+  margin-bottom: 2rem;
+`;
 const A = styled.a``;
 
 const IndexPage = () => (
@@ -70,6 +75,12 @@ const IndexPage = () => (
         Loading...
       </SignForm>
       <Col>
+        <HelpText>
+          {
+            'Please note that pledge signatures are manually reviewed and updated periodically, so your name will not show up on the site right away.'
+          }
+        </HelpText>
+
         <ColHeader>FAQs</ColHeader>
 
         <ColSubheader>


### PR DESCRIPTION
This puts a disclaimer about when your signature will show up underneath the form. A similar disclaimer already shows up after you sign, but I've still received a few questions about it.

<img width="797" alt="Screen Shot 2019-04-15 at 1 13 18 PM" src="https://user-images.githubusercontent.com/163940/56162202-459ed300-5f80-11e9-8527-a89603a4d10e.png">
