### PR TITLE
Ignore gsheets API integration secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Secrets
+client_secret.json
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
Surprised this wasn't already in `.gitignore`...