### PR TITLE
Trim name and title

### DIFF
--- a/src/components/signatories.js
+++ b/src/components/signatories.js
@@ -13,7 +13,7 @@ export default function Signatories() {
     <UL>
       {signers.map(({name, jobtitle}, index) => (
         <LI key={`${name}_${index}`}>
-          {[name, jobtitle].filter(Boolean).join(', ')}
+          {[name, jobtitle].filter(Boolean).map(s => s.trim()).join(', ')}
         </LI>
       ))}
     </UL>

--- a/src/components/signatories.js
+++ b/src/components/signatories.js
@@ -13,7 +13,10 @@ export default function Signatories() {
     <UL>
       {signers.map(({name, jobtitle}, index) => (
         <LI key={`${name}_${index}`}>
-          {[name, jobtitle].filter(Boolean).map(s => s.trim()).join(', ')}
+          {[name, jobtitle]
+            .filter(Boolean)
+            .map(s => s.trim())
+            .join(', ')}
         </LI>
       ))}
     </UL>


### PR DESCRIPTION
Some names and titles have extra spaces between the name and the comma, this trims those strings when building the list.